### PR TITLE
Correct typo in association index

### DIFF
--- a/src/association/index.md
+++ b/src/association/index.md
@@ -27,7 +27,7 @@ The full list of its goals as well as its organization can be found in the artic
 The association was founded in September 2022, and started accepting memberships in Fall 2023.
 
 
-## Memberhips
+## Memberships
 
 The MATSim Association currently offers the following membership levels:
 


### PR DESCRIPTION
The `Memberships` section title is currently `Memberhips`, seemed easiest just to fix it myself.