### PR TITLE
conferences: Add FreighTSim2026

### DIFF
--- a/src/conferences/FreighTSim2026/index.md
+++ b/src/conferences/FreighTSim2026/index.md
@@ -1,0 +1,19 @@
+---
+permalink: /conferences/freightsim2026/index.html
+title: 'FreighTSim 2026'
+description: 'The next (4th) International Symposium on Multi-Agent Freight Transport Simulation (FreighTSim) will be on September 09, 2026, in Berlin, Germany.'
+layout: event
+date: 2026-09-09
+date_display: September 09th 2026
+location: Berlin, Germany
+---
+
+<div class="lead">
+
+The next (4th) International Symposium on Multi-Agent Freight Transport Simulation (FreighTSim) will be on September 09, 2026, in Berlin, Germany.
+
+</div>
+
+ It will be jointly organized by the German Aerospace Center (DLR) and the Technische Universität Berlin (TU Berlin).
+
+We will update this page with more information closer to the date.


### PR DESCRIPTION
Add page for the 4th FreighTSim on 09/09/2026 in Berlin, Germany.